### PR TITLE
Fix path comments for auth-service events

### DIFF
--- a/backend/services/auth-service/internal/events/account_events.go
+++ b/backend/services/auth-service/internal/events/account_events.go
@@ -1,4 +1,4 @@
-// File: internal/events/handlers/account_events.go
+// File: internal/events/account_events.go
 
 package handlers
 

--- a/backend/services/auth-service/internal/events/consumer.go
+++ b/backend/services/auth-service/internal/events/consumer.go
@@ -1,4 +1,4 @@
-// File: internal/events/kafka/consumer.go
+// File: internal/events/consumer.go
 
 package kafka
 

--- a/backend/services/auth-service/internal/events/user_events.go
+++ b/backend/services/auth-service/internal/events/user_events.go
@@ -1,4 +1,4 @@
-// File: internal/events/handlers/user_events.go
+// File: internal/events/user_events.go
 
 package handlers
 


### PR DESCRIPTION
## Summary
- correct path comments in event files

## Testing
- `go vet ./internal/events` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_68480862f18c832bb8eca761f0b3bcdf