### PR TITLE
Refactor account service initialization

### DIFF
--- a/backend/services/account-service/cmd/account-service/main_test.go
+++ b/backend/services/account-service/cmd/account-service/main_test.go
@@ -1,0 +1,19 @@
+// File: backend/services/account-service/cmd/account-service/main_test.go
+package main
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/wizarding-anonymous/gaming_platform/backend/services/account-service/config"
+	"testing"
+)
+
+func TestStartHTTPServer(t *testing.T) {
+	router := gin.New()
+	cfg := &config.Config{}
+	cfg.HTTPPort = 8080
+
+	srv := startHTTPServer(cfg, router)
+	assert.Equal(t, ":8080", srv.Addr)
+	assert.Equal(t, router, srv.Handler)
+}


### PR DESCRIPTION
## Summary
- refactor `main.go` to use helper functions
- add `initDB`, `initServices`, `startHTTPServer`, and `loadConfig`
- add unit test for HTTP server initialization

## Testing
- `go test ./...` *(fails: directory prefix . does not contain modules listed in go.work)*

------
https://chatgpt.com/codex/tasks/task_e_684831499da0832bba30a1021b765719