### PR TITLE
Add env var config and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,21 @@ This monorepo contains the code for a gaming platform inspired by Steam. It is s
 - **configs/** - configuration templates and environment files.
 
 Each service under `backend/services` is managed independently with its own Makefile and configuration.
+
+## Required Environment Variables
+
+The configuration in `configs/config.yaml` expects the following environment variables when running in production:
+
+- `VK_APP_ID` – OAuth application ID for VK
+- `VK_APP_SECRET` – OAuth secret for VK
+- `OK_APP_ID` – OAuth application ID for Odnoklassniki
+- `OK_APP_SECRET_KEY` – OAuth secret key for Odnoklassniki
+- `OK_APP_PUBLIC_KEY` – Public key for Odnoklassniki
+- `TELEGRAM_BOT_TOKEN` – Telegram bot token
+- `JWT_PRIVATE_KEY_PATH` – Path to the RSA private key
+- `JWT_PUBLIC_KEY_PATH` – Path to the RSA public key
+- `JWT_HMAC_SECRET_KEY` – HMAC secret used for internal tokens
+- `OAUTH_STATE_SECRET` – HMAC secret used for OAuth state tokens
+- `TOTP_ENCRYPTION_KEY` – 32‑byte key used to encrypt TOTP secrets
+
+A template for Helm secret values can be found at `backend/services/auth-service/deployments/helm/auth-service/values-secrets-template.yaml`.

--- a/backend/services/auth-service/deployments/helm/auth-service/values-secrets-template.yaml
+++ b/backend/services/auth-service/deployments/helm/auth-service/values-secrets-template.yaml
@@ -1,0 +1,12 @@
+# File: backend/services/auth-service/deployments/helm/auth-service/values-secrets-template.yaml
+# Template for production secrets. Replace values with real credentials.
+
+secrets:
+  dbPassword: ""
+  redisPassword: ""
+  jwtSecret: ""
+  kafkaUsername: ""
+  kafkaPassword: ""
+  telegramBotToken: ""
+  vaultToken: ""
+  serviceApiKey: ""

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -38,15 +38,15 @@ jwt:
     expires_in: "24h"
   password_reset_token:
     expires_in: "1h"
-  rsa_private_key_path: "configs/keys/dev_private_key.pem"
-  rsa_public_key_path: "configs/keys/dev_public_key.pem"
+  rsa_private_key_path: "${JWT_PRIVATE_KEY_PATH}"
+  rsa_public_key_path: "${JWT_PUBLIC_KEY_PATH}"
   jwks_key_id: "auth-service-main-key"
   issuer: "yourplatform.com/auth"
   audience: "yourplatform.com/api"
   refresh_token_byte_length: 32
-  hmac_secret_key: "a_secure_hmac_secret_for_internal_tokens_like_state_or_challenge"
+  hmac_secret_key: "${JWT_HMAC_SECRET_KEY}"
   oauth_state_cookie_ttl: "10m"
-  oauth_state_secret: "another_different_secure_hmac_secret_for_oauth_state_tokens"
+  oauth_state_secret: "${OAUTH_STATE_SECRET}"
   mfa_challenge_token_ttl: "5m"
 
 security:
@@ -83,7 +83,7 @@ security:
 mfa:
   enabled: true
   totp_issuer_name: "YourPlatform"
-  totp_encryption_key: "0000000000000000000000000000000000000000000000000000000000000000" # Placeholder 64 hex chars for 32 bytes
+  totp_encryption_key: "${TOTP_ENCRYPTION_KEY}"
   totp_backup_code_count: 10
 
 logging:
@@ -103,8 +103,8 @@ telemetry:
 
 oauth_providers:
   vk:
-    client_id: "YOUR_VK_APP_ID"
-    client_secret: "YOUR_VK_APP_SECRET"
+    client_id: "${VK_APP_ID}"
+    client_secret: "${VK_APP_SECRET}"
     redirect_url: "http://localhost:8080/api/v1/auth/oauth/vk/callback"
     auth_url: "https://oauth.vk.com/authorize"
     token_url: "https://oauth.vk.com/access_token"
@@ -114,15 +114,15 @@ oauth_providers:
       v: "5.199"
       request_email_scope: "true"
   odnoklassniki:
-    client_id: "YOUR_OK_APP_ID"
-    client_secret: "YOUR_OK_APP_SECRET_KEY"
+    client_id: "${OK_APP_ID}"
+    client_secret: "${OK_APP_SECRET_KEY}"
     redirect_url: "http://localhost:8080/api/v1/auth/oauth/ok/callback"
     auth_url: "https://connect.ok.ru/oauth/authorize"
     token_url: "https://api.ok.ru/oauth/token.do"
     user_info_url: "https://api.ok.ru/fb.do"
     scopes: ["GET_EMAIL", "VALUABLE_ACCESS"]
     provider_specific:
-      application_public_key: "YOUR_OK_APP_PUBLIC_KEY"
+      application_public_key: "${OK_APP_PUBLIC_KEY}"
 
 telegram:
-  bot_token: "YOUR_TELEGRAM_BOT_TOKEN"
+  bot_token: "${TELEGRAM_BOT_TOKEN}"


### PR DESCRIPTION
## Summary
- reference secrets via environment variables in `configs/config.yaml`
- document required environment variables
- add Helm values template for secrets

## Testing
- `make -f backend/Makefile test` *(fails: no required module provides package)*

------
https://chatgpt.com/codex/tasks/task_e_684838ee4dd8832b80f4fb323a527f2b