### PR TITLE
Implement OAuth error redirects

### DIFF
--- a/backend/services/auth-service/internal/config/config.go
+++ b/backend/services/auth-service/internal/config/config.go
@@ -11,19 +11,20 @@ import (
 )
 
 type Config struct {
-	Server         ServerConfig                   `mapstructure:"server"`
-	Database       DatabaseConfig                 `mapstructure:"database"`
-	Redis          RedisConfig                    `mapstructure:"redis"`
-	Kafka          KafkaConfig                    `mapstructure:"kafka"`
-	JWT            JWTConfig                      `mapstructure:"jwt"`
-	Security       SecurityConfig                 `mapstructure:"security"`
-	MFA            MFAConfig                      `mapstructure:"mfa"`
-	Logging        LoggingConfig                  `mapstructure:"logging"`
-	Telemetry      TelemetryConfig                `mapstructure:"telemetry"`
-	OAuthProviders map[string]OAuthProviderConfig `mapstructure:"oauth_providers"`
-	Telegram       TelegramConfig                 `mapstructure:"telegram"`
-	HIBP           HIBPConfig                     `mapstructure:"hibp"`
-	Captcha        CaptchaConfig                  `mapstructure:"captcha"`
+	Server            ServerConfig                   `mapstructure:"server"`
+	Database          DatabaseConfig                 `mapstructure:"database"`
+	Redis             RedisConfig                    `mapstructure:"redis"`
+	Kafka             KafkaConfig                    `mapstructure:"kafka"`
+	JWT               JWTConfig                      `mapstructure:"jwt"`
+	Security          SecurityConfig                 `mapstructure:"security"`
+	MFA               MFAConfig                      `mapstructure:"mfa"`
+	Logging           LoggingConfig                  `mapstructure:"logging"`
+	Telemetry         TelemetryConfig                `mapstructure:"telemetry"`
+	OAuthProviders    map[string]OAuthProviderConfig `mapstructure:"oauth_providers"`
+	Telegram          TelegramConfig                 `mapstructure:"telegram"`
+	HIBP              HIBPConfig                     `mapstructure:"hibp"`
+	Captcha           CaptchaConfig                  `mapstructure:"captcha"`
+	OAuthErrorPageURL string                         `mapstructure:"oauth_error_page_url"`
 }
 
 type HIBPConfig struct {


### PR DESCRIPTION
## Summary
- add `OAuthErrorPageURL` to configuration
- redirect to error page from OAuth callback on errors
- test URL formation for various callback errors

## Testing
- `go test ./...` *(fails: no required module provides packages)*

------
https://chatgpt.com/codex/tasks/task_e_684862279f28832baa277b8802b3dd49