### PR TITLE
Add Go module proxy setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,19 @@ The configuration in `configs/config.yaml` expects the following environment var
 - `TOTP_ENCRYPTION_KEY` – 32‑byte key used to encrypt TOTP secrets
 
 A template for Helm secret values can be found at `backend/services/auth-service/deployments/helm/auth-service/values-secrets-template.yaml`.
+
+## Configuring Go Modules
+
+To prevent `Forbidden` errors when fetching dependencies, configure Go to bypass the default proxy and download modules directly from GitHub:
+
+```bash
+go env -w GOPROXY=direct
+```
+
+If your organization provides its own mirror, replace `direct` with that proxy URL:
+
+```bash
+go env -w GOPROXY=https://your.corp.proxy/,direct
+```
+
+The helper script `setup-go-proxy.sh` in the repository root automates this step.

--- a/setup-go-proxy.sh
+++ b/setup-go-proxy.sh
@@ -1,0 +1,17 @@
+# File: setup-go-proxy.sh
+#!/bin/bash
+
+# Configure Go modules to fetch dependencies directly from GitHub.
+# Run this script if you encounter 'Forbidden' errors when downloading modules.
+# For corporate environments with a custom mirror, replace 'direct' with the proxy URL.
+
+set -e
+
+if [ -z "$1" ]; then
+    echo "Setting GOPROXY=direct"
+    go env -w GOPROXY=direct
+else
+    echo "Setting GOPROXY=$1"
+    go env -w GOPROXY=$1
+fi
+


### PR DESCRIPTION
## Summary
- document GOPROXY setup for direct access or corporate mirror
- add helper script to configure GOPROXY

## Testing
- `go test ./...` *(fails: module requirements missing)*
- `make -f backend/Makefile test` *(fails: go modules not found)*

------
https://chatgpt.com/codex/tasks/task_e_684990fe2194832bb71e02b0dc4d7711