### PR TITLE
Add local setup guide for auth service

### DIFF
--- a/backend/services/auth-service/README.md
+++ b/backend/services/auth-service/README.md
@@ -103,8 +103,8 @@ auth-service/
 
 1. Клонировать репозиторий:
    ```bash
-   git clone https://github.com/gaiming/auth-service.git
-   cd auth-service
+   git clone https://github.com/wizarding-anonymous/gaming_platform.git
+   cd gaming_platform/backend/services/auth-service
    ```
 
 2. Установить зависимости:
@@ -112,25 +112,27 @@ auth-service/
    go mod download
    ```
 
-3. Запустить зависимости через Docker Compose:
+3. Запустить сервисы зависимостей:
    ```bash
    docker-compose up -d postgres redis kafka
    ```
 
-4. Применить миграции:
+4. Применить миграции (можно пропустить, если `auto_migrate: true`):
    ```bash
-   go run migrations/migrations.go up
+   make db-migrate-up
    ```
 
 5. Запустить сервис:
    ```bash
-   go run cmd/auth-service/main.go
+   make run
    ```
 
 Альтернативно, можно запустить весь сервис через Docker Compose:
 ```bash
 docker-compose up -d
 ```
+
+Более подробная инструкция по локальному запуску и тестированию расположена в [docs/local_setup_and_testing.md](docs/local_setup_and_testing.md).
 
 ## API
 

--- a/backend/services/auth-service/docs/local_setup_and_testing.md
+++ b/backend/services/auth-service/docs/local_setup_and_testing.md
@@ -1,0 +1,78 @@
+<!-- File: backend/services/auth-service/docs/local_setup_and_testing.md -->
+# Локальный запуск и тестирование Auth Service
+
+Инструкция описывает полный процесс подготовки окружения, запуска микросервиса **Auth Service** и выполнения тестов.
+
+## Предварительные требования
+
+- **Go 1.21+**
+- **Docker** и **Docker Compose**
+- **git**
+
+## Шаг 1. Клонировать репозиторий
+
+```bash
+git clone https://github.com/wizarding-anonymous/gaming_platform.git
+cd gaming_platform/backend/services/auth-service
+```
+
+## Шаг 2. Настроить переменные окружения
+
+Скопируйте пример файла окружения и при необходимости измените значения:
+
+```bash
+cp env.example .env
+# Отредактируйте .env, указав параметры подключения к Postgres, Redis и Kafka
+```
+
+## Шаг 3. Установить зависимости Go
+
+```bash
+go mod download
+```
+
+(или `make deps` для выполнения той же команды из Makefile.)
+
+## Шаг 4. Запустить сервисы зависимостей
+
+```bash
+docker-compose up -d postgres redis kafka
+```
+
+Эта команда поднимет PostgreSQL, Redis и Kafka (с Zookeeper). Дождитесь, пока контейнеры станут `healthy`.
+
+## Шаг 5. Применить миграции базы данных
+
+Можно полагаться на автоматическое применение миграций при старте сервиса (`auto_migrate: true` в конфигурации) либо выполнить их вручную:
+
+```bash
+make db-migrate-up
+```
+
+## Шаг 6. Запустить Auth Service
+
+```bash
+make run
+```
+
+Сервис будет доступен на `http://localhost:8080`. Документацию API можно открыть по адресу `http://localhost:8080/swagger/index.html`.
+
+## Шаг 7. Выполнить тесты
+
+Убедитесь, что контейнеры с БД и Redis продолжают работать, затем запустите:
+
+```bash
+make test
+```
+
+Команда выполнит все unit и integration тесты (`go test ./...`).
+
+## Шаг 8. Завершение работы
+
+Чтобы остановить все запущенные контейнеры, выполните:
+
+```bash
+docker-compose down
+```
+
+На этом локальный запуск и тестирование завершены.


### PR DESCRIPTION
## Summary
- document how to run auth-service locally and execute tests
- update main README for auth-service with revised commands and link to the new guide

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684992add0a0832baa2a707ad58a5df5