### PR TITLE
Add dockerignore for auth-service modules

### DIFF
--- a/backend/services/auth-service/.dockerignore
+++ b/backend/services/auth-service/.dockerignore
@@ -1,0 +1,3 @@
+# File: backend/services/auth-service/.dockerignore
+go.mod
+go.sum


### PR DESCRIPTION
## Summary
- add `.dockerignore` for auth-service to exclude go modules
- confirm Dockerfile uses multi-stage build that copies go.mod and go.sum before rest of source

## Testing
- `docker build -t auth-service-test ./backend/services/auth-service` *(fails: cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6849ae40de78832b831103569e89867a