### PR TITLE
Remove version keys from Compose files

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,5 +1,4 @@
 # File: backend/docker-compose.yml
-version: '3.8'
 
 services:
   # Инфраструктурные сервисы

--- a/backend/services/auth-service/docker-compose.yml
+++ b/backend/services/auth-service/docker-compose.yml
@@ -1,7 +1,5 @@
 # File: backend/services/auth-service/docker-compose.yml
 
-version: '3.8'
-
 services:
   auth-service:
     build:


### PR DESCRIPTION
## Summary
- drop deprecated `version` key from Compose configurations

## Testing
- `go test ./...` *(fails: directory prefix does not contain modules)*

------
https://chatgpt.com/codex/tasks/task_e_6849b5676a88832baca449ad5d4144ff