### PR TITLE
Add send-email validation hook

### DIFF
--- a/git/hooks/sendemail-validate.sample
+++ b/git/hooks/sendemail-validate.sample
@@ -1,0 +1,92 @@
+#!/bin/sh
+# File: git/hooks/sendemail-validate.sample
+# Usage: copy this file to .git/hooks/sendemail-validate to enable validation before sending patches.
+
+# An example hook script to validate a patch (and/or patch series) before
+# sending it via email.
+#
+# The hook should exit with non-zero status after issuing an appropriate
+# message if it wants to prevent the email(s) from being sent.
+#
+# To enable this hook, rename this file to "sendemail-validate".
+#
+# By default, it will only check that the patch(es) can be applied on top of
+# the default upstream branch without conflicts in a secondary worktree. After
+# validation (successful or not) of the last patch of a series, the worktree
+# will be deleted.
+#
+# The following config variables can be set to change the default remote and
+# remote ref that are used to apply the patches against:
+#
+#   sendemail.validateRemote (default: origin)
+#   sendemail.validateRemoteRef (default: HEAD)
+#
+# This script performs basic validation on patches before sending via email.
+# Replace or extend these checks to fit project needs.
+
+validate_cover_letter () {
+        file="$1"
+        if command -v aspell >/dev/null 2>&1; then
+                if aspell list < "$file" | grep -q .; then
+                        echo "sendemail-validate: spelling issues found in $file" >&2
+                        return 1
+                fi
+        fi
+        return 0
+}
+
+validate_patch () {
+        file="$1"
+        # Ensure that the patch applies without conflicts.
+        git am -3 "$file" || return 1
+        # Check for whitespace errors after applying the patch.
+        git diff-tree --check HEAD >/dev/null || return 1
+        return 0
+}
+
+validate_series () {
+        files=$(git ls-files '*.go')
+        if [ -n "$files" ] && command -v gofmt >/dev/null 2>&1; then
+                unfmt=$(gofmt -l $files)
+                if [ -n "$unfmt" ]; then
+                        echo "sendemail-validate: gofmt needs to be run on:" >&2
+                        echo "$unfmt" >&2
+                        return 1
+                fi
+        fi
+        return 0
+}
+
+# main -------------------------------------------------------------------------
+
+if test "$GIT_SENDEMAIL_FILE_COUNTER" = 1
+then
+	remote=$(git config --default origin --get sendemail.validateRemote) &&
+	ref=$(git config --default HEAD --get sendemail.validateRemoteRef) &&
+	worktree=$(mktemp --tmpdir -d sendemail-validate.XXXXXXX) &&
+	git worktree add -fd --checkout "$worktree" "refs/remotes/$remote/$ref" &&
+	git config --replace-all sendemail.validateWorktree "$worktree"
+else
+	worktree=$(git config --get sendemail.validateWorktree)
+fi || {
+	echo "sendemail-validate: error: failed to prepare worktree" >&2
+	exit 1
+}
+
+unset GIT_DIR GIT_WORK_TREE
+cd "$worktree" &&
+
+if grep -q "^diff --git " "$1"
+then
+	validate_patch "$1"
+else
+	validate_cover_letter "$1"
+fi &&
+
+if test "$GIT_SENDEMAIL_FILE_COUNTER" = "$GIT_SENDEMAIL_FILE_TOTAL"
+then
+	git config --unset-all sendemail.validateWorktree &&
+	trap 'git worktree remove -ff "$worktree"' EXIT &&
+	validate_series
+fi
+exit $?


### PR DESCRIPTION
## Summary
- add git send-email validation script to `git/hooks`

## Testing
- `go work sync`
- `go vet ./...` *(fails: directory prefix does not contain modules)*
- `make -f backend/Makefile lint` *(fails: make returned non-zero exit status)*

------
https://chatgpt.com/codex/tasks/task_e_6849b96f54dc832b88ded05b862fc5f7