### PR TITLE
Implement MFA backup code persistence

### DIFF
--- a/backend/services/auth-service/internal/domain/repository/mfa_backup_code_repository.go
+++ b/backend/services/auth-service/internal/domain/repository/mfa_backup_code_repository.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/wizarding-anonymous/gaming_platform/backend/services/auth-service/internal/domain/models"
 	domainErrors "github.com/wizarding-anonymous/gaming_platform/backend/services/auth-service/internal/domain/errors" // Ensure this import
+	"github.com/wizarding-anonymous/gaming_platform/backend/services/auth-service/internal/domain/models"
 )
 
 // MFABackupCodeRepository defines the interface for interacting with MFA backup code data.
@@ -22,6 +22,10 @@ type MFABackupCodeRepository interface {
 	// FindByUserIDAndCodeHash retrieves an unused MFA backup code by the user's ID and the hashed code.
 	// Returns domainErrors.ErrNotFound if not found or already used.
 	FindByUserIDAndCodeHash(ctx context.Context, userID uuid.UUID, codeHash string) (*models.MFABackupCode, error)
+
+	// FindByUserID retrieves all MFA backup codes for a user that have not been used yet.
+	// Returns an empty slice if none exist.
+	FindByUserID(ctx context.Context, userID uuid.UUID) ([]*models.MFABackupCode, error)
 
 	// MarkAsUsed marks a specific backup code (by its primary ID) as used.
 	MarkAsUsed(ctx context.Context, id uuid.UUID, usedAt time.Time) error

--- a/backend/services/auth-service/internal/domain/service/mfa_verify.go
+++ b/backend/services/auth-service/internal/domain/service/mfa_verify.go
@@ -205,7 +205,14 @@ func (s *mfaLogicService) isUserAuthorizedForSensitiveAction(ctx context.Context
 		}
 		return match, nil
 	case "totp":
-		return s.Verify2FACode(ctx, userID, verificationToken, models.MFATypeTOTP)
+		valid, err := s.Verify2FACode(ctx, userID, verificationToken, models.MFATypeTOTP)
+		if err != nil {
+			if errors.Is(err, domainErrors.ErrInvalid2FACode) {
+				return s.Verify2FACode(ctx, userID, verificationToken, models.MFATypeBackup)
+			}
+			return false, err
+		}
+		return valid, nil
 	case "backup":
 		return s.Verify2FACode(ctx, userID, verificationToken, models.MFATypeBackup)
 	default:


### PR DESCRIPTION
## Summary
- extend MFABackupCodeRepository with FindByUserID
- store and retrieve backup codes in PostgreSQL implementation
- enable backup code fallback when disabling 2FA
- test repository retrieval by user

## Testing
- `go test ./...` *(fails: no required module provides packages)*

------
https://chatgpt.com/codex/tasks/task_e_6849c1613c28832bb8d37bff20150430