### PR TITLE
Add permission validation in role service

### DIFF
--- a/backend/services/auth-service/internal/domain/repository/interfaces/permission_repository.go
+++ b/backend/services/auth-service/internal/domain/repository/interfaces/permission_repository.go
@@ -1,0 +1,38 @@
+// File: backend/services/auth-service/internal/domain/repository/interfaces/permission_repository.go
+package interfaces
+
+import (
+	"context"
+
+	domainErrors "github.com/wizarding-anonymous/gaming_platform/backend/services/auth-service/internal/domain/errors"
+	"github.com/wizarding-anonymous/gaming_platform/backend/services/auth-service/internal/domain/models"
+)
+
+// PermissionRepository defines the interface for interacting with permission data.
+type PermissionRepository interface {
+	// Create persists a new permission to the database.
+	// The ID for the permission (string) should be set on the models.Permission object.
+	Create(ctx context.Context, permission *models.Permission) error
+
+	// FindByID retrieves a permission by its unique ID (string).
+	// Returns domainErrors.ErrPermissionNotFound if no permission is found.
+	FindByID(ctx context.Context, id string) (*models.Permission, error)
+
+	// FindByName retrieves a permission by its unique name.
+	// Returns domainErrors.ErrPermissionNotFound if no permission is found.
+	FindByName(ctx context.Context, name string) (*models.Permission, error)
+
+	// Update modifies an existing permission's details in the database.
+	Update(ctx context.Context, permission *models.Permission) error
+
+	// Delete removes a permission from the database.
+	// This is a hard delete as the permissions table does not have soft-delete columns per spec.
+	Delete(ctx context.Context, id string) error
+
+	// List retrieves all permissions from the database.
+	// Consider adding pagination/filtering parameters if the number of permissions can be large.
+	List(ctx context.Context /* params ListPermissionsParams */) ([]*models.Permission, error)
+}
+
+// Note: domainErrors.ErrPermissionNotFound should be used from the errors package.
+// type ListPermissionsParams struct { ... } // Can be added if filtering/pagination is needed.

--- a/backend/services/auth-service/internal/service/role_service_permission.go
+++ b/backend/services/auth-service/internal/service/role_service_permission.go
@@ -39,18 +39,16 @@ func (s *RoleService) AssignPermissionToRole(ctx context.Context, roleID string,
 		return domainErrors.ErrRoleNotFound
 	}
 
-	if s.permissionRepo != nil {
-		if _, err := s.permissionRepo.FindByID(ctx, permissionID); err != nil {
-			if errors.Is(err, domainErrors.ErrPermissionNotFound) {
-				s.logger.Error("AssignPermissionToRole: Permission not found", zap.String("permissionID", permissionID))
-				auditDetails["error"] = domainErrors.ErrPermissionNotFound.Error()
-				auditDetails["details"] = err.Error()
-				s.auditLogRecorder.RecordEvent(ctx, actorID, "role_permission_assign", models.AuditLogStatusFailure, targetRoleIDStr, models.AuditTargetTypeRole, auditDetails, ipAddress, userAgent)
-				return domainErrors.ErrPermissionNotFound
-			}
-			s.logger.Error("AssignPermissionToRole: failed to fetch permission", zap.Error(err))
-			return err
+	if _, err := s.permissionRepo.FindByID(ctx, permissionID); err != nil {
+		if errors.Is(err, domainErrors.ErrPermissionNotFound) {
+			s.logger.Error("AssignPermissionToRole: Permission not found", zap.String("permissionID", permissionID))
+			auditDetails["error"] = domainErrors.ErrPermissionNotFound.Error()
+			auditDetails["details"] = err.Error()
+			s.auditLogRecorder.RecordEvent(ctx, actorID, "role_permission_assign", models.AuditLogStatusFailure, targetRoleIDStr, models.AuditTargetTypeRole, auditDetails, ipAddress, userAgent)
+			return domainErrors.ErrPermissionNotFound
 		}
+		s.logger.Error("AssignPermissionToRole: failed to fetch permission", zap.Error(err))
+		return err
 	}
 
 	err = s.roleRepo.AssignPermissionToRole(ctx, roleID, permissionID)
@@ -119,18 +117,16 @@ func (s *RoleService) RemovePermissionFromRole(ctx context.Context, roleID strin
 		return domainErrors.ErrRoleNotFound
 	}
 
-	if s.permissionRepo != nil {
-		if _, err := s.permissionRepo.FindByID(ctx, permissionID); err != nil {
-			if errors.Is(err, domainErrors.ErrPermissionNotFound) {
-				s.logger.Error("RemovePermissionFromRole: Permission not found", zap.String("permissionID", permissionID))
-				auditDetails["error"] = domainErrors.ErrPermissionNotFound.Error()
-				auditDetails["details"] = err.Error()
-				s.auditLogRecorder.RecordEvent(ctx, actorID, "role_permission_revoke", models.AuditLogStatusFailure, targetRoleIDStr, models.AuditTargetTypeRole, auditDetails, ipAddress, userAgent)
-				return domainErrors.ErrPermissionNotFound
-			}
-			s.logger.Error("RemovePermissionFromRole: failed to fetch permission", zap.Error(err))
-			return err
+	if _, err := s.permissionRepo.FindByID(ctx, permissionID); err != nil {
+		if errors.Is(err, domainErrors.ErrPermissionNotFound) {
+			s.logger.Error("RemovePermissionFromRole: Permission not found", zap.String("permissionID", permissionID))
+			auditDetails["error"] = domainErrors.ErrPermissionNotFound.Error()
+			auditDetails["details"] = err.Error()
+			s.auditLogRecorder.RecordEvent(ctx, actorID, "role_permission_revoke", models.AuditLogStatusFailure, targetRoleIDStr, models.AuditTargetTypeRole, auditDetails, ipAddress, userAgent)
+			return domainErrors.ErrPermissionNotFound
 		}
+		s.logger.Error("RemovePermissionFromRole: failed to fetch permission", zap.Error(err))
+		return err
 	}
 
 	err = s.roleRepo.RemovePermissionFromRole(ctx, roleID, permissionID)


### PR DESCRIPTION
## Summary
- introduce a PermissionRepository interface under domain repository interfaces
- check for permission existence in RoleService before linking or unlinking

## Testing
- `go test ./...` *(fails: module dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6849d0b942b0832ba5e4175d5d3535e5