### PR TITLE
Add auth event publishing hooks

### DIFF
--- a/backend/services/auth-service/cmd/auth-service/main.go
+++ b/backend/services/auth-service/cmd/auth-service/main.go
@@ -321,6 +321,7 @@ func main() {
 		RoleRepo:       roleRepo,
 		PermissionRepo: permissionRepo,
 		Logger:         logger,
+		KafkaProducer:  kafkaProducer,
 	})
 	// var userService *service.UserService // Placeholder - needs proper initialization with specific repos
 	userService := service.NewUserService(

--- a/backend/services/auth-service/internal/domain/models/events.go
+++ b/backend/services/auth-service/internal/domain/models/events.go
@@ -272,6 +272,7 @@ const (
 	AuthRoleDeletedV1           = "auth.rbac.role_deleted.v1"
 	AuthUserRoleAssignedV1      = "auth.rbac.user_role_assigned.v1"
 	AuthUserRoleRevokedV1       = "auth.rbac.user_role_revoked.v1"
+	AuthUserRolesChangedV1      = "auth.user.roles_changed.v1"
 	AuthRolePermissionChangedV1 = "auth.rbac.role_permission_changed.v1"
 	// AuthPermissionAssignedToRoleV1 = "auth.rbac.permission_assigned_to_role.v1"
 	// AuthPermissionRevokedFromRoleV1 = "auth.rbac.permission_revoked_from_role.v1"


### PR DESCRIPTION
## Summary
- add `AuthUserRolesChangedV1` constant
- publish roles changed events in RBAC service
- emit registered and logout events in auth logic service
- wire Kafka producer into RBAC service setup

## Testing
- `go test ./...` *(fails: module dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6849d62d8930832bb6f6f4c250de2293