### PR TITLE
Remove ListSessionsParams from FindByUserID

### DIFF
--- a/backend/services/auth-service/internal/domain/repository/interfaces/session_repository.go
+++ b/backend/services/auth-service/internal/domain/repository/interfaces/session_repository.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/wizarding-anonymous/gaming_platform/backend/services/auth-service/internal/domain/models"
 	domainErrors "github.com/wizarding-anonymous/gaming_platform/backend/services/auth-service/internal/domain/errors" // Added for ErrNotFound
+	"github.com/wizarding-anonymous/gaming_platform/backend/services/auth-service/internal/domain/models"
 )
 
 // SessionRepository defines the interface for managing user sessions in the data store.
@@ -24,9 +24,8 @@ type SessionRepository interface {
 	// Returns domainErrors.ErrNotFound if no session is found.
 	FindByID(ctx context.Context, id uuid.UUID) (*models.Session, error)
 
-	// FindByUserID retrieves all sessions for a specific user. (Changed from GetUserSessions)
-	// TODO: Consider if params models.ListSessionsParams is still needed or if this should return all (active) sessions.
-	// For now, keeping it simple. The original GetUserSessions with filters might be a separate, more specific method.
+	// FindByUserID retrieves all sessions for a specific user.
+	// It returns every session row for the user without additional filtering.
 	FindByUserID(ctx context.Context, userID uuid.UUID) ([]*models.Session, error)
 
 	// UpdateLastActivityAt updates the last activity timestamp for a given session ID.
@@ -53,11 +52,11 @@ type SessionRepository interface {
 	// The actual data stored might be minimal, just enough for quick validation or lookup.
 	// This can help reduce database load for frequent session checks.
 	StoreInCache(ctx context.Context, sessionID uuid.UUID, userID uuid.UUID, ttl time.Duration) error // Renamed
-	
+
 	// GetUserIDFromCache retrieves the UserID associated with a sessionID from the cache.
 	// Returns domainErrors.ErrNotFound if the sessionID is not found in the cache or if it has expired.
 	GetUserIDFromCache(ctx context.Context, sessionID uuid.UUID) (uuid.UUID, error)
-	
+
 	// RemoveFromCache explicitly removes a session from the cache, e.g., on logout.
 	RemoveFromCache(ctx context.Context, sessionID uuid.UUID) error // Renamed
 }

--- a/backend/services/auth-service/internal/handler/http/me_handler.go
+++ b/backend/services/auth-service/internal/handler/http/me_handler.go
@@ -365,15 +365,13 @@ func (h *MeHandler) ListMySessions(c *gin.Context) {
 
 	currentSessionIDStr, currentSessionExists := c.Get("sessionID") // Assuming middleware.GinContextSessionIDKey is "sessionID"
 
-	// Get all active sessions by default.
-	sessions, total, err := h.sessionService.GetUserSessions(c.Request.Context(), userID, models.ListSessionsParams{ActiveOnly: true, PageSize: 0})
+	// Get all active sessions
+	sessions, err := h.sessionService.GetActiveUserSessions(c.Request.Context(), userID)
 	if err != nil {
-		h.logger.Error("ListMySessions: sessionService.GetUserSessions failed", zap.Error(err), zap.String("userID", userID.String()))
+		h.logger.Error("ListMySessions: sessionService.GetActiveUserSessions failed", zap.Error(err), zap.String("userID", userID.String()))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve sessions."})
 		return
 	}
-
-	_ = total // total might be useful if pagination is fully implemented with headers
 
 	sessionResponses := make([]SessionResponse, len(sessions))
 	for i, session := range sessions {

--- a/backend/services/auth-service/internal/handler/http/user_handler.go
+++ b/backend/services/auth-service/internal/handler/http/user_handler.go
@@ -104,12 +104,8 @@ func (h *UserHandler) ListSessions(c *gin.Context) {
 		return
 	}
 
-	// Prepare params for listing (e.g., active only, pagination if needed)
-	// For now, list all, activeOnly true by default in service or repo if not specified.
-	// The SessionService.GetUserSessions expects ListSessionsParams
-	listParams := models.ListSessionsParams{ActiveOnly: true, PageSize: 100, Page: 1} // Example params
-
-	sessions, totalCount, err := h.sessionService.GetUserSessions(c.Request.Context(), userID, listParams)
+	// List active sessions for the user
+	sessions, err := h.sessionService.GetActiveUserSessions(c.Request.Context(), userID)
 	if err != nil {
 		h.handleError(c, err) // Use existing handleError or a more specific one
 		return
@@ -122,10 +118,7 @@ func (h *UserHandler) ListSessions(c *gin.Context) {
 	}
 
 	SuccessResponse(c.Writer, h.logger, http.StatusOK, gin.H{
-		"sessions":    sessionResponses,
-		"total_count": totalCount,
-		"page":        listParams.Page,
-		"page_size":   listParams.PageSize,
+		"sessions": sessionResponses,
 	})
 }
 


### PR DESCRIPTION
## Summary
- simplify session retrieval interface
- implement `FindByUserID` without filter params
- update service and handlers to use new repo method
- adjust PostgreSQL tests accordingly

## Testing
- `go test ./...` *(fails: directory prefix does not contain modules)*
- `(cd backend/services/auth-service && go test ./...)` *(fails to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6849dab593d8832bb9d5138a174b94d4