### PR TITLE
Fix file banners in auth-service

### DIFF
--- a/backend/services/auth-service/api/swagger/auth.swagger.json
+++ b/backend/services/auth-service/api/swagger/auth.swagger.json
@@ -1,4 +1,4 @@
-// File: api/swagger/auth.swagger.json
+// File: backend/services/auth-service/api/swagger/auth.swagger.json
 
 {
   "swagger": "2.0",

--- a/backend/services/auth-service/migrations/000001_create_initial_tables.down.sql
+++ b/backend/services/auth-service/migrations/000001_create_initial_tables.down.sql
@@ -1,4 +1,4 @@
-// File: migrations/000001_create_initial_tables.down.sql
+// File: backend/services/auth-service/migrations/000001_create_initial_tables.down.sql
 
 -- Удаление таблицы кодов восстановления
 DROP TABLE IF EXISTS recovery_codes;

--- a/backend/services/auth-service/migrations/000001_create_initial_tables.up.sql
+++ b/backend/services/auth-service/migrations/000001_create_initial_tables.up.sql
@@ -1,4 +1,4 @@
-// File: migrations/000001_create_initial_tables.up.sql
+// File: backend/services/auth-service/migrations/000001_create_initial_tables.up.sql
 
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 

--- a/backend/services/auth-service/migrations/000002_seed_initial_data.down.sql
+++ b/backend/services/auth-service/migrations/000002_seed_initial_data.down.sql
@@ -1,4 +1,4 @@
-// File: migrations/000002_seed_initial_data.down.sql
+// File: backend/services/auth-service/migrations/000002_seed_initial_data.down.sql
 
 -- Удаление всех связей ролей и разрешений
 DELETE FROM role_permissions;

--- a/backend/services/auth-service/migrations/000002_seed_initial_data.up.sql
+++ b/backend/services/auth-service/migrations/000002_seed_initial_data.up.sql
@@ -1,4 +1,4 @@
-// File: migrations/000002_seed_initial_data.up.sql
+// File: backend/services/auth-service/migrations/000002_seed_initial_data.up.sql
 
 -- Создание базовых ролей
 INSERT INTO roles (id, name, description, created_at, updated_at)

--- a/backend/services/auth-service/migrations/000003_add_user_roles.down.sql
+++ b/backend/services/auth-service/migrations/000003_add_user_roles.down.sql
@@ -1,4 +1,4 @@
-// File: migrations/000003_add_user_roles.down.sql
+// File: backend/services/auth-service/migrations/000003_add_user_roles.down.sql
 
 -- Удаление триггеров
 DROP TRIGGER IF EXISTS trigger_audit_user_roles ON user_roles;

--- a/backend/services/auth-service/migrations/000003_add_user_roles.up.sql
+++ b/backend/services/auth-service/migrations/000003_add_user_roles.up.sql
@@ -1,4 +1,4 @@
-// File: migrations/000003_add_user_roles.up.sql
+// File: backend/services/auth-service/migrations/000003_add_user_roles.up.sql
 
 -- Добавление ролей пользователей
 CREATE TABLE IF NOT EXISTS user_roles (

--- a/backend/services/auth-service/migrations/000004_add_role_permissions.down.sql
+++ b/backend/services/auth-service/migrations/000004_add_role_permissions.down.sql
@@ -1,4 +1,4 @@
-// File: migrations/000004_add_role_permissions.down.sql
+// File: backend/services/auth-service/migrations/000004_add_role_permissions.down.sql
 
 -- Удаление триггеров
 DROP TRIGGER IF EXISTS trigger_audit_role_permissions ON role_permissions;

--- a/backend/services/auth-service/migrations/000004_add_role_permissions.up.sql
+++ b/backend/services/auth-service/migrations/000004_add_role_permissions.up.sql
@@ -1,4 +1,4 @@
-// File: migrations/000004_add_role_permissions.up.sql
+// File: backend/services/auth-service/migrations/000004_add_role_permissions.up.sql
 
 -- Добавление разрешений для ролей
 CREATE TABLE IF NOT EXISTS role_permissions (

--- a/backend/services/auth-service/migrations/000005_add_sessions.up.sql
+++ b/backend/services/auth-service/migrations/000005_add_sessions.up.sql
@@ -1,4 +1,4 @@
-// File: migrations/000005_add_sessions.up.sql
+// File: backend/services/auth-service/migrations/000005_add_sessions.up.sql
 
 -- Создание таблицы сессий
 CREATE TABLE IF NOT EXISTS sessions (

--- a/backend/services/auth-service/specification/Auth_Service_Detailed_Specification.md
+++ b/backend/services/auth-service/specification/Auth_Service_Detailed_Specification.md
@@ -1,4 +1,4 @@
-<!-- File: backend/services/auth-service/specification_final/Auth_Service_Detailed_Specification.md -->
+<!-- File: backend/services/auth-service/specification/Auth_Service_Detailed_Specification.md -->
 # Детализированная Спецификация Микросервиса Аутентификации (Auth Service)
 
 **Версия:** 2.0

--- a/backend/services/auth-service/specification/auth_api_grpc.md
+++ b/backend/services/auth-service/specification/auth_api_grpc.md
@@ -1,4 +1,4 @@
-<!-- File: backend/services/auth-service/specification_final/auth_api_grpc.md -->
+<!-- File: backend/services/auth-service/specification/auth_api_grpc.md -->
 # Auth Service: gRPC API Specification
 
 **Version:** 1.0

--- a/backend/services/auth-service/specification/auth_api_rest.md
+++ b/backend/services/auth-service/specification/auth_api_rest.md
@@ -1,4 +1,4 @@
-<!-- File: backend/services/auth-service/specification_final/auth_api_rest.md -->
+<!-- File: backend/services/auth-service/specification/auth_api_rest.md -->
 # Auth Service: REST API Specification
 
 **Version:** 1.0

--- a/backend/services/auth-service/specification/auth_data_model.md
+++ b/backend/services/auth-service/specification/auth_data_model.md
@@ -1,4 +1,4 @@
-<!-- File: backend/services/auth-service/specification_final/auth_data_model.md -->
+<!-- File: backend/services/auth-service/specification/auth_data_model.md -->
 # Auth Service: Data Model and Database Schema
 
 **Version:** 1.0

--- a/backend/services/auth-service/specification/auth_integrations.md
+++ b/backend/services/auth-service/specification/auth_integrations.md
@@ -1,4 +1,4 @@
-<!-- File: backend/services/auth-service/specification_final/auth_integrations.md -->
+<!-- File: backend/services/auth-service/specification/auth_integrations.md -->
 # Auth Service: Integrations Specification
 
 **Version:** 1.0

--- a/backend/services/auth-service/specification/auth_security_compliance.md
+++ b/backend/services/auth-service/specification/auth_security_compliance.md
@@ -1,4 +1,4 @@
-<!-- File: backend/services/auth-service/specification_final/auth_security_compliance.md -->
+<!-- File: backend/services/auth-service/specification/auth_security_compliance.md -->
 # Auth Service: Security and Compliance Specification
 
 **Version:** 1.0

--- a/backend/services/auth-service/specification/auth_service_logic.md
+++ b/backend/services/auth-service/specification/auth_service_logic.md
@@ -1,4 +1,4 @@
-<!-- File: backend/services/auth-service/specification_final/auth_service_logic.md -->
+<!-- File: backend/services/auth-service/specification/auth_service_logic.md -->
 # Auth Service: Service Logic and Workflows
 
 **Version:** 1.0

--- a/backend/services/auth-service/specification/auth_service_overview.md
+++ b/backend/services/auth-service/specification/auth_service_overview.md
@@ -1,4 +1,4 @@
-<!-- File: backend/services/auth-service/specification_final/auth_service_overview.md -->
+<!-- File: backend/services/auth-service/specification/auth_service_overview.md -->
 # Auth Service Overview
 
 **Version:** 1.0


### PR DESCRIPTION
## Summary
- correct banner paths in markdown specs referencing `specification_final` directory
- update migrations and swagger file banners to use full relative path

## Testing
- `go test ./...` *(fails: module download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684a68878d64832bab6777c0cf3e19ad