### PR TITLE
Refactor auth service main setup

### DIFF
--- a/backend/services/auth-service/cmd/auth-service/config.go
+++ b/backend/services/auth-service/cmd/auth-service/config.go
@@ -1,0 +1,8 @@
+// File: backend/services/auth-service/cmd/auth-service/config.go
+package main
+
+import "github.com/wizarding-anonymous/gaming_platform/backend/services/auth-service/internal/config"
+
+func loadConfig() (*config.Config, error) {
+	return config.LoadConfig()
+}

--- a/backend/services/auth-service/cmd/auth-service/external.go
+++ b/backend/services/auth-service/cmd/auth-service/external.go
@@ -1,0 +1,63 @@
+// File: backend/services/auth-service/cmd/auth-service/external.go
+package main
+
+import (
+	"fmt"
+
+	"github.com/Shopify/sarama"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.uber.org/zap"
+
+	"github.com/golang-migrate/migrate/v4"
+	_ "github.com/golang-migrate/migrate/v4/database/postgres"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/wizarding-anonymous/gaming_platform/backend/services/auth-service/internal/config"
+	"github.com/wizarding-anonymous/gaming_platform/backend/services/auth-service/internal/events/kafka"
+	infraDbPostgres "github.com/wizarding-anonymous/gaming_platform/backend/services/auth-service/internal/infrastructure/database/postgres"
+	repoRedis "github.com/wizarding-anonymous/gaming_platform/backend/services/auth-service/internal/repository/redis"
+)
+
+func initDatabase(cfg *config.Config, logger *zap.Logger) (*pgxpool.Pool, error) {
+	if cfg.Database.AutoMigrate {
+		logger.Info("Running database migrations")
+		migrationURL := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s",
+			cfg.Database.User, cfg.Database.Password, cfg.Database.Host, cfg.Database.Port, cfg.Database.DBName, cfg.Database.SSLMode)
+		m, err := migrate.New("file://migrations", migrationURL)
+		if err != nil {
+			return nil, fmt.Errorf("create migration instance: %w", err)
+		}
+		if err := m.Up(); err != nil && err != migrate.ErrNoChange {
+			return nil, fmt.Errorf("apply migrations: %w", err)
+		}
+		logger.Info("Migrations applied successfully")
+	}
+
+	return infraDbPostgres.NewDBPool(cfg.Database)
+}
+
+func initRedis(cfg *config.Config) (*repoRedis.RedisClient, error) {
+	return repoRedis.NewRedisClient(cfg.Redis)
+}
+
+func initKafkaProducer(cfg *config.Config, logger *zap.Logger) (*kafka.Producer, error) {
+	return kafka.NewProducer(cfg.Kafka.Brokers, logger, "urn:service:auth")
+}
+
+func initKafkaConsumer(cfg *config.Config, logger *zap.Logger) (*kafka.ConsumerGroup, error) {
+	saramaCfg := sarama.NewConfig()
+	saramaCfg.Version = sarama.V2_8_0_0
+	saramaCfg.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategyRange
+	saramaCfg.Consumer.Offsets.Initial = sarama.OffsetOldest
+	saramaCfg.Consumer.Return.Errors = true
+
+	consumerGroupCfg := kafka.NewConsumerGroupConfig{
+		Brokers:       cfg.Kafka.Brokers,
+		Topics:        cfg.Kafka.Consumer.Topics,
+		GroupID:       cfg.Kafka.Consumer.GroupID,
+		SaramaConfig:  saramaCfg,
+		Logger:        logger,
+		InitialOffset: sarama.OffsetOldest,
+	}
+
+	return kafka.NewConsumerGroup(consumerGroupCfg)
+}

--- a/backend/services/auth-service/cmd/auth-service/servers.go
+++ b/backend/services/auth-service/cmd/auth-service/servers.go
@@ -1,0 +1,44 @@
+// File: backend/services/auth-service/cmd/auth-service/servers.go
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/wizarding-anonymous/gaming_platform/backend/services/auth-service/internal/config"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+)
+
+func startHTTPServer(cfg *config.Config, handler http.Handler, logger *zap.Logger) *http.Server {
+	srv := &http.Server{
+		Addr:         fmt.Sprintf(":%d", cfg.Server.Port),
+		Handler:      handler,
+		ReadTimeout:  cfg.Server.ReadTimeout,
+		WriteTimeout: cfg.Server.WriteTimeout,
+		IdleTimeout:  cfg.Server.IdleTimeout,
+	}
+
+	go func() {
+		logger.Info("Starting HTTP server", zap.Int("port", cfg.Server.Port))
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Fatal("Failed to start HTTP server", zap.Error(err))
+		}
+	}()
+
+	return srv
+}
+
+func startGRPCServer(cfg *config.Config, grpcServer *grpc.Server, logger *zap.Logger) {
+	go func() {
+		lis, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.GRPC.Port))
+		if err != nil {
+			logger.Fatal("Failed to listen for gRPC", zap.Error(err))
+		}
+		logger.Info("Starting gRPC server", zap.Int("port", cfg.GRPC.Port))
+		if err := grpcServer.Serve(lis); err != nil {
+			logger.Fatal("Failed to start gRPC server", zap.Error(err))
+		}
+	}()
+}

--- a/backend/services/auth-service/internal/utils/shutdown/shutdown.go
+++ b/backend/services/auth-service/internal/utils/shutdown/shutdown.go
@@ -1,0 +1,33 @@
+// File: backend/services/auth-service/internal/utils/shutdown/shutdown.go
+package shutdown
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+)
+
+// Wait блокирует выполнение до получения сигнала завершения
+// и выполняет graceful shutdown HTTP и gRPC серверов.
+func Wait(httpSrv *http.Server, grpcSrv *grpc.Server, timeout time.Duration, logger *zap.Logger) {
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	<-quit
+	logger.Info("Shutting down servers...")
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if err := httpSrv.Shutdown(ctx); err != nil {
+		logger.Error("HTTP server forced to shutdown", zap.Error(err))
+	}
+
+	grpcSrv.GracefulStop()
+	logger.Info("Servers exited properly")
+}


### PR DESCRIPTION
## Summary
- split config loading, server startup and service initialization into separate modules
- add graceful shutdown helper
- use new helpers in auth-service main

## Testing
- `go test ./...` *(fails: directory prefix does not contain modules)*

------
https://chatgpt.com/codex/tasks/task_e_684a6bf1414c832b9e82e7a98f711962