### PR TITLE
Add token service tests

### DIFF
--- a/backend/services/auth-service/tests/integration/compose_integration_test.go
+++ b/backend/services/auth-service/tests/integration/compose_integration_test.go
@@ -1,0 +1,93 @@
+// File: backend/services/auth-service/tests/integration/compose_integration_test.go
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/golang-migrate/migrate/v4"
+	_ "github.com/golang-migrate/migrate/v4/database/postgres"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wizarding-anonymous/gaming_platform/backend/services/auth-service/internal/domain/models"
+	repoPostgres "github.com/wizarding-anonymous/gaming_platform/backend/services/auth-service/internal/domain/repository/postgres"
+	repoRedis "github.com/wizarding-anonymous/gaming_platform/backend/services/auth-service/internal/domain/repository/redis"
+	"go.uber.org/zap"
+)
+
+var (
+	db          *pgxpool.Pool
+	redisClient *redis.Client
+)
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+
+	pgHost := getEnv("TEST_DB_HOST", "localhost")
+	pgPort := getEnv("TEST_DB_PORT", "5433")
+	dsn := fmt.Sprintf("postgres://postgres:postgres@%s:%s/auth_test?sslmode=disable", pgHost, pgPort)
+	var err error
+	db, err = pgxpool.New(ctx, dsn)
+	if err != nil {
+		fmt.Printf("db connect error: %v\n", err)
+		os.Exit(1)
+	}
+
+	mig, err := migrate.New("file://../../migrations", dsn)
+	if err == nil {
+		_ = mig.Up()
+	}
+
+	redisHost := getEnv("TEST_REDIS_HOST", "localhost")
+	redisPort := getEnv("TEST_REDIS_PORT", "6379")
+	redisClient = redis.NewClient(&redis.Options{Addr: fmt.Sprintf("%s:%s", redisHost, redisPort)})
+	if err = redisClient.Ping(ctx).Err(); err != nil {
+		fmt.Printf("redis ping error: %v\n", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+	db.Close()
+	os.Exit(code)
+}
+
+func getEnv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func TestUserRepositoryAndTokenCache(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+
+	userRepo := repoPostgres.NewUserRepositoryPostgres(db)
+	tokenCache := repoRedis.NewTokenCache(redisClient, logger, time.Hour)
+
+	user := &models.User{ID: uuid.New(), Username: "docker_user", Email: "docker@example.com", PasswordHash: "hash", Status: models.UserStatusActive}
+	err := userRepo.Create(ctx, user)
+	require.NoError(t, err)
+
+	fetched, err := userRepo.FindByID(ctx, user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, user.Email, fetched.Email)
+
+	token := &models.Token{ID: uuid.New(), UserID: user.ID, TokenType: string(models.TokenTypeAccess), TokenValue: "tval", ExpiresAt: time.Now().Add(time.Minute)}
+	require.NoError(t, tokenCache.Set(ctx, token))
+	fromVal, err := tokenCache.GetByValue(ctx, token.TokenValue)
+	require.NoError(t, err)
+	assert.Equal(t, token.ID, fromVal.ID)
+
+	require.NoError(t, tokenCache.RevokeToken(ctx, token.TokenValue))
+	revoked, err := tokenCache.IsRevoked(ctx, token.TokenValue)
+	require.NoError(t, err)
+	assert.True(t, revoked)
+}

--- a/backend/services/auth-service/tests/integration/docker-compose.yml
+++ b/backend/services/auth-service/tests/integration/docker-compose.yml
@@ -1,0 +1,15 @@
+# File: backend/services/auth-service/tests/integration/docker-compose.yml
+version: "3.8"
+services:
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: auth_test
+    ports:
+      - "5433:5432"
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"

--- a/backend/services/auth-service/tests/internal/service/token_service_validate_test.go
+++ b/backend/services/auth-service/tests/internal/service/token_service_validate_test.go
@@ -1,0 +1,106 @@
+// File: backend/services/auth-service/tests/internal/service/token_service_validate_test.go
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	domainErrors "github.com/wizarding-anonymous/gaming_platform/backend/services/auth-service/internal/domain/errors"
+	domainInterfaces "github.com/wizarding-anonymous/gaming_platform/backend/services/auth-service/internal/domain/interfaces"
+	"github.com/wizarding-anonymous/gaming_platform/backend/services/auth-service/internal/service"
+)
+
+type MockRedisClient struct{ mock.Mock }
+
+func (m *MockRedisClient) IsBlacklisted(ctx context.Context, token string) (bool, error) {
+	args := m.Called(ctx, token)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockRedisClient) AddToBlacklist(ctx context.Context, token string, ttl time.Duration) error {
+	return m.Called(ctx, token, ttl).Error(0)
+}
+
+type MockTokenMgmt struct{ mock.Mock }
+
+func (m *MockTokenMgmt) GenerateAccessToken(userID string, username string, roles []string, permissions []string, sessionID string) (string, *domainInterfaces.Claims, error) {
+	args := m.Called(userID, username, roles, permissions, sessionID)
+	if args.Get(1) != nil {
+		return args.String(0), args.Get(1).(*domainInterfaces.Claims), args.Error(2)
+	}
+	return args.String(0), nil, args.Error(2)
+}
+
+func (m *MockTokenMgmt) ValidateAccessToken(tokenString string) (*domainInterfaces.Claims, error) {
+	args := m.Called(tokenString)
+	if args.Get(0) != nil {
+		return args.Get(0).(*domainInterfaces.Claims), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *MockTokenMgmt) GenerateRefreshTokenValue() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+func (m *MockTokenMgmt) GetRefreshTokenExpiry() time.Duration {
+	args := m.Called()
+	return args.Get(0).(time.Duration)
+}
+func (m *MockTokenMgmt) GetJWKS() (map[string]interface{}, error) {
+	args := m.Called()
+	if args.Get(0) != nil {
+		return args.Get(0).(map[string]interface{}), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockTokenMgmt) Generate2FAChallengeToken(userID string) (string, error) {
+	args := m.Called(userID)
+	return args.String(0), args.Error(1)
+}
+func (m *MockTokenMgmt) Validate2FAChallengeToken(tokenString string) (string, error) {
+	args := m.Called(tokenString)
+	return args.String(0), args.Error(1)
+}
+func (m *MockTokenMgmt) GenerateStateJWT(claims *domainInterfaces.OAuthStateClaims, secret string, ttl time.Duration) (string, error) {
+	args := m.Called(claims, secret, ttl)
+	return args.String(0), args.Error(1)
+}
+func (m *MockTokenMgmt) ValidateStateJWT(tokenString string, secret string) (*domainInterfaces.OAuthStateClaims, error) {
+	args := m.Called(tokenString, secret)
+	if args.Get(0) != nil {
+		return args.Get(0).(*domainInterfaces.OAuthStateClaims), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func TestValidateAccessToken_Blacklisted(t *testing.T) {
+	ctx := context.Background()
+	redisMock := new(MockRedisClient)
+	redisMock.On("IsBlacklisted", ctx, "token").Return(true, nil)
+
+	svc := &service.TokenService{redisClient: redisMock}
+	_, err := svc.ValidateAccessToken(ctx, "token")
+	assert.ErrorIs(t, err, domainErrors.ErrRevokedToken)
+	redisMock.AssertExpectations(t)
+}
+
+func TestRevokeToken_AddsToBlacklist(t *testing.T) {
+	ctx := context.Background()
+	redisMock := new(MockRedisClient)
+	tokenMgmt := new(MockTokenMgmt)
+	claims := &domainInterfaces.Claims{RegisteredClaims: domainInterfaces.Claims{}.RegisteredClaims}
+	claims.ExpiresAt = &domainInterfaces.Claims{}.RegisteredClaims.ExpiresAt
+	claims.ExpiresAt.Time = time.Now().Add(time.Hour)
+	tokenMgmt.On("ValidateAccessToken", "token").Return(claims, nil)
+	redisMock.On("AddToBlacklist", ctx, "token", mock.AnythingOfType("time.Duration")).Return(nil)
+
+	svc := &service.TokenService{redisClient: redisMock, tokenMgmtService: tokenMgmt}
+	err := svc.RevokeToken(ctx, "token")
+	assert.NoError(t, err)
+	redisMock.AssertExpectations(t)
+	tokenMgmt.AssertExpectations(t)
+}


### PR DESCRIPTION
## Summary
- add unit tests for token validation and revocation
- add integration test with Postgres and Redis using docker-compose

## Testing
- `go test ./...` *(fails: directory prefix does not contain modules)*

------
https://chatgpt.com/codex/tasks/task_e_684a7e19c0f0832bade62b32777cb64e