### PR TITLE
Improve secret management

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ The production configuration in `configs/config.prod.yaml` expects the following
 - `OAUTH_STATE_SECRET` – HMAC secret used for OAuth state tokens
 - `TOTP_ENCRYPTION_KEY` – 32‑byte key used to encrypt TOTP secrets
 
+Secrets like RSA keys and the TOTP encryption key should be provided via secure
+stores (e.g., Kubernetes Secrets or HashiCorp Vault) rather than being committed
+directly in environment files. The service reads these values at startup using
+the environment variables above.
+
 A template for Helm secret values can be found at `backend/services/auth-service/deployments/helm/auth-service/values-secrets-template.yaml`.
 
 ## Configuring Go Modules

--- a/backend/services/auth-service/README.md
+++ b/backend/services/auth-service/README.md
@@ -180,9 +180,14 @@ docker-compose up -d
 - `KAFKA_BROKERS` - Список брокеров Kafka
 - `JWT_PRIVATE_KEY_PATH`: Путь к приватному ключу RSA для подписи JWT-токенов.
 - `JWT_PUBLIC_KEY_PATH`: Путь к публичному ключу RSA для проверки JWT-токенов.
+- `TOTP_ENCRYPTION_KEY`: 32-байтный ключ в hex-формате для шифрования TOTP секрета.
 - `ACCESS_TOKEN_TTL` - Время жизни Access Token (в секундах)
 - `REFRESH_TOKEN_TTL` - Время жизни Refresh Token (в секундах)
 - `TELEGRAM_BOT_TOKEN` - Токен Telegram Bot API
+
+Секретные ключи (RSA и TOTP) рекомендуется хранить во внешних секрет-хранилищах
+(Vault, Kubernetes Secrets) и передавать сервису через переменные окружения или
+смонтированные файлы.
 
 ## Развертывание
 

--- a/backend/services/auth-service/internal/config/config.go
+++ b/backend/services/auth-service/internal/config/config.go
@@ -89,14 +89,16 @@ type TokenConfig struct {
 }
 
 type JWTConfig struct {
-	AccessTokenTTL         time.Duration `mapstructure:"access_token_ttl"`
-	RefreshTokenTTL        time.Duration `mapstructure:"refresh_token_ttl"`
-	EmailVerificationToken TokenConfig   `mapstructure:"email_verification_token"`
-	PasswordResetToken     TokenConfig   `mapstructure:"password_reset_token"`
-	RSAPrivateKeyPEM       string        `mapstructure:"rsa_private_key_pem"`
-	RSAPublicKeyPEM        string        `mapstructure:"rsa_public_key_pem"`
-	JWKSKeyID              string        `mapstructure:"jwks_key_id"`
-	Issuer                 string        `mapstructure:"issuer"`
+        AccessTokenTTL         time.Duration `mapstructure:"access_token_ttl"`
+        RefreshTokenTTL        time.Duration `mapstructure:"refresh_token_ttl"`
+        EmailVerificationToken TokenConfig   `mapstructure:"email_verification_token"`
+        PasswordResetToken     TokenConfig   `mapstructure:"password_reset_token"`
+        RSAPrivateKeyPEM       string        `mapstructure:"rsa_private_key_pem"`
+        RSAPrivateKeyPEMFile   string        `mapstructure:"rsa_private_key_path"`
+        RSAPublicKeyPEM        string        `mapstructure:"rsa_public_key_pem"`
+        RSAPublicKeyPEMFile    string        `mapstructure:"rsa_public_key_path"`
+        JWKSKeyID              string        `mapstructure:"jwks_key_id"`
+        Issuer                 string        `mapstructure:"issuer"`
 	Audience               string        `mapstructure:"audience"`
 	RefreshTokenByteLength uint32        `mapstructure:"refresh_token_byte_length"`
 	OAuthStateCookieTTL    time.Duration `mapstructure:"oauth_state_cookie_ttl"`

--- a/backend/services/auth-service/internal/config/loader.go
+++ b/backend/services/auth-service/internal/config/loader.go
@@ -44,12 +44,28 @@ func LoadConfig() (*Config, error) {
 	}
 
 	// Загрузка конфигурации в структуру
-	var config Config
-	if err := viper.Unmarshal(&config); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
-	}
+        var config Config
+        if err := viper.Unmarshal(&config); err != nil {
+                return nil, fmt.Errorf("failed to unmarshal config: %w", err)
+        }
 
-	return &config, nil
+        // Load RSA keys from file paths if provided
+        if config.JWT.RSAPrivateKeyPEM == "" && config.JWT.RSAPrivateKeyPEMFile != "" {
+                keyBytes, err := os.ReadFile(config.JWT.RSAPrivateKeyPEMFile)
+                if err != nil {
+                        return nil, fmt.Errorf("failed to read RSA private key: %w", err)
+                }
+                config.JWT.RSAPrivateKeyPEM = string(keyBytes)
+        }
+        if config.JWT.RSAPublicKeyPEM == "" && config.JWT.RSAPublicKeyPEMFile != "" {
+                keyBytes, err := os.ReadFile(config.JWT.RSAPublicKeyPEMFile)
+                if err != nil {
+                        return nil, fmt.Errorf("failed to read RSA public key: %w", err)
+                }
+                config.JWT.RSAPublicKeyPEM = string(keyBytes)
+        }
+
+        return &config, nil
 }
 
 // setDefaults устанавливает значения по умолчанию для конфигурации


### PR DESCRIPTION
## Summary
- document secure storage for RSA/TOTP secrets
- expose TOTP_ENCRYPTION_KEY in Auth Service README
- support loading RSA keys from files in config loader
- expose RSA key file paths in JWT configuration

## Testing
- `go test ./...` *(fails: module downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684a874df92c832bb8c2a39ac6bccbc8