### PR TITLE
Fix producer creation

### DIFF
--- a/backend/services/account-service/cmd/account-service/main.go
+++ b/backend/services/account-service/cmd/account-service/main.go
@@ -152,10 +152,7 @@ func main() {
 	defer db.Close()
 	defer redisClient.Close()
 
-	kafkaProducer, err := kafka.NewProducer(cfg.Kafka)
-	if err != nil {
-		sugar.Fatalw("Failed to create Kafka producer", "error", err)
-	}
+	kafkaProducer := kafka.NewKafkaEventProducer(cfg.Kafka.Brokers, cfg.App.Name)
 	defer kafkaProducer.Close()
 
 	svcs := initServices(db, redisClient, kafkaProducer, sugar)

--- a/backend/services/account-service/internal/infrastructure/kafka/producer_test.go
+++ b/backend/services/account-service/internal/infrastructure/kafka/producer_test.go
@@ -1,0 +1,20 @@
+// File: backend/services/account-service/internal/infrastructure/kafka/producer_test.go
+package kafka
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewKafkaEventProducer(t *testing.T) {
+	brokers := []string{"localhost:9092"}
+	source := "test-service"
+
+	p := NewKafkaEventProducer(brokers, source)
+
+	require.NotNil(t, p)
+	assert.Equal(t, source, p.sourceName)
+	require.NotNil(t, p.writer)
+}


### PR DESCRIPTION
## Summary
- use `kafka.NewKafkaEventProducer` directly in `main.go`
- add `producer_test.go` for `NewKafkaEventProducer`

## Testing
- `go test ./backend/services/account-service/...` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_684a8f0706fc832b9e0c582bbf6750ca